### PR TITLE
Implement Retry queue flow

### DIFF
--- a/src/AbstractQueue.php
+++ b/src/AbstractQueue.php
@@ -11,6 +11,10 @@ use Queue\Driver\Connection as DriverConnection;
 
 abstract class AbstractQueue implements InterfaceQueue
 {
+    /**
+     * 10 second
+     */
+    const MESSAGE_TIME_TO_LIVE = 10000;
 
     /**
      * @var DriverConnection
@@ -45,5 +49,10 @@ abstract class AbstractQueue implements InterfaceQueue
     public function getExchange()
     {
         return $this->getConnection()->getExchange();
+    }
+
+    public function getTimeToLiveInMilliseconds()
+    {
+        return self::MESSAGE_TIME_TO_LIVE;
     }
 }

--- a/src/ConsumerInterface.php
+++ b/src/ConsumerInterface.php
@@ -2,6 +2,7 @@
 
 namespace Queue;
 
+use Exception\RetryQueueException;
 use Queue\Driver\MessageInterface;
 
 interface ConsumerInterface extends InterfaceQueue
@@ -16,6 +17,7 @@ interface ConsumerInterface extends InterfaceQueue
 
     /**
      * @param MessageInterface $message
+     * @throws RetryQueueException
      * @return void
      */
     public function process(MessageInterface $message);

--- a/src/Exception/RetryQueueException.php
+++ b/src/Exception/RetryQueueException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @author Marco.Souza<marco.souza@tricae.com.br>
+ * @since 2015.09.11
+ *
+ */
+
+namespace Queue\Exception;
+
+class RetryQueueException extends QueueException
+{}

--- a/src/ProducerRetry.php
+++ b/src/ProducerRetry.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Marco.Souza<marco.souza@tricae.com.br>
+ * @since 2015.09.11
+ *
+ */
+
+namespace Queue;
+
+
+use Queue\Driver\Connection as DriverConnection;
+
+final class ProducerRetry extends Producer
+{
+    const RETRY_SUFFIX = '.retry';
+    /**
+     * @var Consumer
+     */
+    protected  $consumer;
+
+    /**
+     * @param Consumer $consumer
+     */
+    public function __construct(Consumer $consumer)
+    {
+        $this->consumer = $consumer;
+        parent::__construct($consumer->getConnection());
+    }
+
+    public function getWorkingQueueName()
+    {
+        // TODO: Improvement this when 'Routing keys' became ready
+        return $this->consumer->getWorkingQueueName().self::RETRY_SUFFIX;
+    }
+
+    public function getWorkingExchangeName()
+    {
+        // TODO: Improvement this when 'Routing keys' became ready
+        return $this->consumer->getWorkingExchangeName().self::RETRY_SUFFIX;
+    }
+
+    public function getQueueArguments()
+    {
+        return array(
+            'x-message-ttl' => array('I', $this->consumer->getTimeToLiveInMilliseconds()),
+            'x-dead-letter-exchange' => array('S', $this->consumer->getWorkingExchangeName())
+        );
+    }
+
+
+}

--- a/tests/Fake/ConsumerFakeWithRetry.php
+++ b/tests/Fake/ConsumerFakeWithRetry.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Marco.Souza<marco.souza@tricae.com.br>
+ * @since 2015.09.11
+ *
+ */
+
+namespace QueueTest\Fake;
+
+use Queue\Consumer;
+use Queue\Driver\MessageInterface;
+use Queue\Exception\RetryQueueException;
+
+class ConsumerFakeWithRetry extends Consumer
+{
+
+    public function getWorkingQueueName()
+    {
+        return 'test.queue.fake';
+    }
+
+    public function getWorkingExchangeName()
+    {
+        return $this->getWorkingQueueName();
+    }
+
+    /**
+     * @param MessageInterface $message
+     * @throws RetryQueueException
+     * @return void
+     */
+    public function process(MessageInterface $message)
+    {
+        throw new RetryQueueException();
+    }
+}

--- a/tests/Unit/ConsumerRetryTest.php
+++ b/tests/Unit/ConsumerRetryTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Marco.Souza<marco.souza@tricae.com.br>
+ * @since 2015.09.11
+ *
+ */
+
+namespace QueueTest\Unit;
+
+
+use Queue\Configuration;
+use Queue\Driver;
+use Queue\DriverManager;
+use QueueTest\Fake\ConsumerFakeWithRetry;
+
+class ConsumerRetryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRetryQueue()
+    {
+        $connection = DriverManager::getConnection(new Configuration(Driver::AMQP, RABBIT_HOST, RABBIT_PORT, RABBIT_USERNAME, RABBIT_PASSWORD));
+        $consumer = new ConsumerFakeWithRetry($connection);
+        $consumer->consume();
+    }
+}
+ 


### PR DESCRIPTION
### What
Implement Retry Queue  Issue #10 
### Why 
To handle some message which can't be handled at this point at time. 
### How 
* Implement with less change to normal current flow, to avoid break current implementation. 
* Implement a final class ProducerRetry to handle dynamically with this using the current consumer. 
* The consume handle some  RetryQueueException to Invoke ProducerRetry and publish. 