### PR TITLE
implemented ack/nack on drivers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "A PHP Lib for Handle Queue (Rabbit, Redis, ...)",
     "type": "library",
     "require": {
+        "php": ">=5.4.0",
         "videlalvaro/php-amqplib": "2.4.*"
     },
     "require-dev": {

--- a/src/Component/BitwiseFlag.php
+++ b/src/Component/BitwiseFlag.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: aspinelli
+ * Date: 9/15/15
+ * Time: 10:08 AM
+ * @author Antonio Spinelli <antonio.spinelli@kanui.com.br>
+ */
+
+namespace Queue\Component;
+
+
+trait BitwiseFlag
+{
+    /**
+     * @var int
+     */
+    protected $flags;
+
+    /**
+     * @param int $flag
+     * @return bool
+     */
+    protected function isFlagSet($flag)
+    {
+        return (($this->flags & $flag) == $flag);
+    }
+
+    /**
+     * @param int $flag
+     * @param bool $value
+     * @return void
+     */
+    protected function setFlag($flag, $value)
+    {
+        if ($value) {
+            $this->flags |= $flag;
+        } else {
+            $this->flags &= ~$flag;
+        }
+    }
+}

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -54,7 +54,7 @@ class Connection implements DriverConnection
     }
 
     /**
-     * @return void
+     * {@inheritdoc}
      */
     public function close()
     {
@@ -62,9 +62,7 @@ class Connection implements DriverConnection
     }
 
     /**
-     * @param MessageInterface $message
-     * @param ProducerInterface $producer
-     * @return void
+     * {@inheritdoc}
      */
     public function publish(MessageInterface $message, ProducerInterface $producer)
     {
@@ -72,18 +70,15 @@ class Connection implements DriverConnection
     }
 
     /**
-     * @param string $message
-     * @param array $properties
-     * @return MessageInterface
+     * {@inheritdoc}
      */
-    public function prepare($message, array $properties = array())
+    public function prepare($message, array $properties = array(), $id = null)
     {
-        return $this->connect()->prepare($message, $properties);
+        return $this->connect()->prepare($message, $properties, $id);
     }
 
     /**
-     * @param ConsumerInterface $consumer
-     * @return MessageInterface|null
+     * {@inheritdoc}
      */
     public function fetchOne(ConsumerInterface $consumer)
     {
@@ -91,10 +86,26 @@ class Connection implements DriverConnection
     }
 
     /**
-     * @return Exchange
+     * {@inheritdoc}
      */
     public function getExchange()
     {
         return $this->connect()->getExchange();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(MessageInterface $message)
+    {
+        $this->connect()->ack($message);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function nack(MessageInterface $message)
+    {
+        $this->connect()->nack($message);
     }
 }

--- a/src/ConsumerInterface.php
+++ b/src/ConsumerInterface.php
@@ -2,7 +2,7 @@
 
 namespace Queue;
 
-use Exception\RetryQueueException;
+use Queue\Exception\RetryQueueException;
 use Queue\Driver\MessageInterface;
 
 interface ConsumerInterface extends InterfaceQueue

--- a/src/Driver/Amqp/Connection.php
+++ b/src/Driver/Amqp/Connection.php
@@ -76,7 +76,7 @@ class Connection implements \Queue\Driver\Connection
         $this->declareQueue($consumer);
         $channel = $this->getChannel();
 
-        $message = $channel->basic_get($consumer->getWorkingQueueName(), AbstractQueue::QUEUE_NOT_ACK);
+        $message = $channel->basic_get($consumer->getWorkingQueueName());
 
         if (!$message) {
             return null;
@@ -144,6 +144,6 @@ class Connection implements \Queue\Driver\Connection
      */
     public function nack(MessageInterface $message)
     {
-        $this->getChannel()->basic_nack($message->getId());
+        $this->getChannel()->basic_nack($message->getId(), false, $message->isRequeue());
     }
 }

--- a/src/Driver/Amqp/Connection.php
+++ b/src/Driver/Amqp/Connection.php
@@ -2,7 +2,6 @@
 
 namespace Queue\Driver\Amqp;
 
-use Queue\Driver\Amqp\AmqpExchange;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPConnection;
 use Queue\AbstractQueue;
@@ -19,9 +18,9 @@ class Connection implements \Queue\Driver\Connection
      */
     private $connection;
     /**
-     * @var AMQPChannel[]
+     * @var AMQPChannel
      */
-    private $channels;
+    private $channel;
 
     public function __construct(ConfigurationInterface $configuration)
     {
@@ -44,7 +43,7 @@ class Connection implements \Queue\Driver\Connection
     }
 
     /**
-     * @return void
+     * {@inheritdoc}
      */
     public function close()
     {
@@ -52,54 +51,54 @@ class Connection implements \Queue\Driver\Connection
     }
 
     /**
-     * @param string $message
-     * @param array $properties
-     * @return MessageInterface
+     * {@inheritdoc}
      */
-    public function prepare($message, array $properties = array())
+    public function prepare($message, array $properties = array(), $id = null)
     {
-        return new Message($message, $properties);
-    }
-
-    public function publish(MessageInterface $message, ProducerInterface $producer)
-    {
-        $this->declareQueue($producer);
-        $channel = $this->getChannel($producer);
-        $channel->basic_publish($message, $producer->getWorkingExchangeName());
+        return new Message($message, $properties, $id);
     }
 
     /**
-     * @param ConsumerInterface $consumer
-     * @return MessageInterface|null
+     * {@inheritdoc}
+     */
+    public function publish(MessageInterface $message, ProducerInterface $producer)
+    {
+        $this->declareQueue($producer);
+        $channel = $this->getChannel();
+        $channel->basic_publish(Message::createAMQPMessage($message), $producer->getWorkingExchangeName());
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function fetchOne(ConsumerInterface $consumer)
     {
         $this->declareQueue($consumer);
-        $channel = $this->getChannel($consumer);
+        $channel = $this->getChannel();
 
-        $message = $channel->basic_get($consumer->getWorkingQueueName(), AbstractQueue::QUEUE_ACK);
+        $message = $channel->basic_get($consumer->getWorkingQueueName(), AbstractQueue::QUEUE_NOT_ACK);
 
         if (!$message) {
             return null;
         }
-        return $this->prepare($message->body);
+
+        return Message::create($message);
     }
 
     /**
-     * @param InterfaceQueue $queue
      * @return AMQPChannel
      */
-    protected function getChannel(InterfaceQueue $queue)
+    protected function getChannel()
     {
-        if (!isset($this->channels[$queue->getWorkingQueueName()])) {
-            $this->channels[$queue->getWorkingQueueName()] = $this->connection->channel();
+        if (!$this->channel) {
+            $this->channel = $this->connection->channel();
         }
-        return $this->channels[$queue->getWorkingQueueName()];
+        return $this->channel;
     }
 
     protected function declareQueue(InterfaceQueue $queue)
     {
-        $channel = $this->getChannel($queue);
+        $channel = $this->getChannel();
         $channel->queue_declare(
             $queue->getWorkingQueueName(),
             AbstractQueue::QUEUE_NOT_PASSIVE,
@@ -125,10 +124,26 @@ class Connection implements \Queue\Driver\Connection
     }
 
     /**
-     * @return AmqpExchange
+     * {@inheritdoc}
      */
     public function getExchange()
     {
         return new AmqpExchange();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(MessageInterface $message)
+    {
+        $this->getChannel()->basic_ack($message->getId());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function nack(MessageInterface $message)
+    {
+        $this->getChannel()->basic_nack($message->getId());
     }
 }

--- a/src/Driver/Amqp/Message.php
+++ b/src/Driver/Amqp/Message.php
@@ -3,20 +3,28 @@
 namespace Queue\Driver\Amqp;
 
 use PhpAmqpLib\Message\AMQPMessage;
-use Queue\Driver\MessageInterface;
+use Queue\Driver\Message as DriverMessage;
+use Queue\Driver\MessageInterface as DriverMessageInterface;
 
-class Message extends AMQPMessage implements MessageInterface
+class Message extends DriverMessage implements MessageInterface
 {
-    public function __construct($body, array $properties = array())
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(AMQPMessage $message)
     {
-        parent::__construct($body, $properties);
+        $id = null;
+        if ($message->has('delivery_tag')) {
+            $id = $message->get('delivery_tag');
+        }
+        return new static($message->body, $message->get_properties(), $id);
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
-    public function getBody()
+    public static function createAMQPMessage(DriverMessageInterface $message)
     {
-        return $this->body;
+        return new AMQPMessage($message->getBody(), $message->getProperties());
     }
 }

--- a/src/Driver/Amqp/MessageInterface.php
+++ b/src/Driver/Amqp/MessageInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Queue\Driver\Amqp;
+
+use PhpAmqpLib\Message\AMQPMessage;
+use Queue\Driver\MessageInterface as DriverMessageInterface;
+
+interface MessageInterface extends DriverMessageInterface
+{
+    /**
+     * @param AMQPMessage $message
+     * @return MessageInterface
+     */
+    public static function create(AMQPMessage $message);
+
+    /**
+     * @param DriverMessageInterface $message
+     * @return AMQPMessage
+     */
+    public static function createAMQPMessage(DriverMessageInterface $message);
+}

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -13,7 +13,6 @@ use Queue\ProducerInterface;
 
 interface Connection
 {
-    const DRIVER_AMQP = 'amqp';
 
     /**
      * @return void
@@ -30,9 +29,10 @@ interface Connection
     /**
      * @param string $message
      * @param array $properties
+     * @param string $id
      * @return MessageInterface
      */
-    public function prepare($message, array $properties = array());
+    public function prepare($message, array $properties = array(), $id = null);
 
     /**
      * @param ConsumerInterface $consumer
@@ -44,4 +44,16 @@ interface Connection
      * @return Exchange
      */
     public function getExchange();
+
+    /**
+     * @param MessageInterface $message
+     * @return void
+     */
+    public function ack(MessageInterface $message);
+
+    /**
+     * @param MessageInterface $message
+     * @return void
+     */
+    public function nack(MessageInterface $message);
 }

--- a/src/Driver/InMemory/Connection.php
+++ b/src/Driver/InMemory/Connection.php
@@ -6,6 +6,7 @@ use Driver\InMemory\InMemoryExchange;
 use Queue\ConfigurationInterface;
 use Queue\ConsumerInterface;
 use Queue\Driver\MessageInterface;
+use Queue\Exception\NotImplementedException;
 use Queue\ProducerInterface;
 
 class Connection implements \Queue\Driver\Connection
@@ -19,21 +20,22 @@ class Connection implements \Queue\Driver\Connection
     {}
 
     /**
-     * @return void
+     * {@inheritdoc}
      */
     public function close()
     {}
 
     /**
-     * @param string $message
-     * @param array $properties
-     * @return MessageInterface
+     * {@inheritdoc}
      */
-    public function prepare($message, array $properties = array())
+    public function prepare($message, array $properties = array(), $id = null)
     {
-        return new Message($message, $properties);
+        return new Message($message, $properties, $id);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function publish(MessageInterface $message, ProducerInterface $producer)
     {
         $connection = $this->getConnection($producer->getWorkingQueueName());
@@ -47,9 +49,9 @@ class Connection implements \Queue\Driver\Connection
         }
         return $this->connection[$queue];
     }
+
     /**
-     * @param ConsumerInterface $consumer
-     * @return MessageInterface|null
+     * {@inheritdoc}
      */
     public function fetchOne(ConsumerInterface $consumer)
     {
@@ -65,10 +67,27 @@ class Connection implements \Queue\Driver\Connection
     }
 
     /**
-     * @return InMemoryExchange
+     * {@inheritdoc}
      */
     public function getExchange()
     {
         return new InMemoryExchange();
+    }
+
+    /**
+     * @param MessageInterface $message
+     * @return void
+     */
+    public function ack(MessageInterface $message)
+    {
+    }
+
+    /**
+     *
+     * @param MessageInterface $message
+     * @return void
+     */
+    public function nack(MessageInterface $message)
+    {
     }
 }

--- a/src/Driver/InMemory/Message.php
+++ b/src/Driver/InMemory/Message.php
@@ -2,22 +2,8 @@
 
 namespace Queue\Driver\InMemory;
 
-use Queue\Driver\MessageInterface;
+use Queue\Driver\Message as DriverMessage;
 
-class Message implements MessageInterface
+class Message extends DriverMessage
 {
-    protected $body;
-
-    public function __construct($body, array $properties = array())
-    {
-        $this->body = $body;
-    }
-
-    /**
-     * @return string
-     */
-    public function getBody()
-    {
-        return $this->body;
-    }
 }

--- a/src/Driver/Message.php
+++ b/src/Driver/Message.php
@@ -2,8 +2,11 @@
 
 namespace Queue\Driver;
 
+use Queue\Component\BitwiseFlag;
+
 class Message implements MessageInterface
 {
+    use BitwiseFlag;
     private $id;
     private $body;
     private $properties;
@@ -47,5 +50,56 @@ class Message implements MessageInterface
     public function hasProperty($name)
     {
         return isset($this->properties[$name]);
+    }
+
+    /**
+     * @param bool $confirm
+     * @return void
+     */
+    public function setAck($confirm = true)
+    {
+        $this->setFlag(self::ACK, $confirm);
+    }
+
+    /**
+     * @param bool $confirm
+     * @return void
+     */
+    public function setNotAck($confirm = true)
+    {
+        $this->setFlag(self::NOT_ACK, $confirm);
+    }
+
+    /**
+     * @param bool $confirm
+     * @return void
+     */
+    public function setRequeue($confirm = true)
+    {
+        $this->setFlag(self::REQUEUE, $confirm);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAck()
+    {
+        return $this->isFlagSet(self::ACK);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNotAck()
+    {
+        return $this->isFlagSet(self::NOT_ACK);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequeue()
+    {
+        return $this->isFlagSet(self::REQUEUE);
     }
 }

--- a/src/Driver/Message.php
+++ b/src/Driver/Message.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Queue\Driver;
+
+class Message implements MessageInterface
+{
+    private $id;
+    private $body;
+    private $properties;
+
+    public function __construct($body, array $properties = array(), $id = null)
+    {
+        $this->body = $body;
+        $this->properties = $properties;
+        $this->id = $id;
+    }
+
+    /**
+     * @return null
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+
+    public function getProperty($name)
+    {
+        return $this->properties[$name];
+    }
+
+    public function hasProperty($name)
+    {
+        return isset($this->properties[$name]);
+    }
+}

--- a/src/Driver/MessageInterface.php
+++ b/src/Driver/MessageInterface.php
@@ -4,6 +4,10 @@ namespace Queue\Driver;
 
 interface MessageInterface
 {
+    const ACK = 1;
+    const NOT_ACK = 2;
+    const REQUEUE = 4;
+
     public function __construct($body, array $properties = array(), $id = null);
 
     /**
@@ -20,4 +24,37 @@ interface MessageInterface
      * @return array
      */
     public function getProperties();
+
+    /**
+     * @param bool $confirm
+     * @return void
+     */
+    public function setAck($confirm = true);
+
+    /**
+     * @param bool $confirm
+     * @return void
+     */
+    public function setNotAck($confirm = true);
+
+    /**
+     * @param bool $confirm
+     * @return void
+     */
+    public function setRequeue($confirm = true);
+
+    /**
+     * @return bool
+     */
+    public function isAck();
+
+    /**
+     * @return bool
+     */
+    public function isNotAck();
+
+    /**
+     * @return bool
+     */
+    public function isRequeue();
 }

--- a/src/Driver/MessageInterface.php
+++ b/src/Driver/MessageInterface.php
@@ -4,10 +4,20 @@ namespace Queue\Driver;
 
 interface MessageInterface
 {
-    public function __construct($body, array $properties = array());
+    public function __construct($body, array $properties = array(), $id = null);
+
+    /**
+     * @return string
+     */
+    public function getId();
 
     /**
      * @return string
      */
     public function getBody();
+
+    /**
+     * @return array
+     */
+    public function getProperties();
 }

--- a/src/InterfaceQueue.php
+++ b/src/InterfaceQueue.php
@@ -7,8 +7,6 @@
 
 namespace Queue;
 
-use Queue\Driver\MessageInterface;
-
 interface InterfaceQueue
 {
 

--- a/tests/Fake/ConsumerFake.php
+++ b/tests/Fake/ConsumerFake.php
@@ -26,13 +26,12 @@ class ConsumerFake extends Consumer
     }
 
     /**
-     * @param MessageInterface $message
-     * @return void
+     * {@inheritdoc}
      */
     public function process(MessageInterface $message)
     {
         echo $message->getBody();
-        $this->getConnection()->ack($message);
+        $message->setAck();
     }
 
     public function getExchange()

--- a/tests/Fake/ConsumerFake.php
+++ b/tests/Fake/ConsumerFake.php
@@ -17,12 +17,12 @@ class ConsumerFake extends Consumer
 
     public function getWorkingQueueName()
     {
-        return 'test.queue';
+        return 'test.queue.fake';
     }
 
     public function getWorkingExchangeName()
     {
-        return 'amqp.direct';
+        return 'test.queue.fake';
     }
 
     /**
@@ -32,5 +32,13 @@ class ConsumerFake extends Consumer
     public function process(MessageInterface $message)
     {
         echo $message->getBody();
+        $this->getConnection()->ack($message);
+    }
+
+    public function getExchange()
+    {
+        $exchange = parent::getExchange();
+        $exchange->setAutoDelete(ExchangeInterface::AMQP_AUTO_DELETE_FALSE);
+        return $exchange;
     }
 }

--- a/tests/Fake/ConsumerFakeWithRetry.php
+++ b/tests/Fake/ConsumerFakeWithRetry.php
@@ -10,6 +10,7 @@ namespace QueueTest\Fake;
 use Queue\Consumer;
 use Queue\Driver\MessageInterface;
 use Queue\Exception\RetryQueueException;
+use Queue\ExchangeInterface;
 
 class ConsumerFakeWithRetry extends Consumer
 {
@@ -32,5 +33,11 @@ class ConsumerFakeWithRetry extends Consumer
     public function process(MessageInterface $message)
     {
         throw new RetryQueueException();
+    }
+    public function getExchange()
+    {
+        $exchange = parent::getExchange();
+        $exchange->setAutoDelete(ExchangeInterface::AMQP_AUTO_DELETE_FALSE);
+        return $exchange;
     }
 }

--- a/tests/Fake/ProducerFake.php
+++ b/tests/Fake/ProducerFake.php
@@ -16,18 +16,18 @@ class ProducerFake extends Producer
 
     public function getWorkingQueueName()
     {
-        return 'test.queue';
+        return 'test.queue.fake';
     }
 
     public function getWorkingExchangeName()
     {
-        return 'amqp.direct';
+        return 'test.queue.fake';
     }
 
     public function getExchange()
     {
         $exchange = parent::getExchange();
-        $exchange->setAutoDelete(ExchangeInterface::AMQP_AUTO_DELETE_TRUE);
+        $exchange->setAutoDelete(ExchangeInterface::AMQP_AUTO_DELETE_FALSE);
         return $exchange;
     }
 

--- a/tests/Unit/ProducerTest.php
+++ b/tests/Unit/ProducerTest.php
@@ -46,6 +46,7 @@ class ProducerTest extends \PHPUnit_Framework_TestCase {
 
     public function testProducerFanout()
     {
+        $this->markTestIncomplete('This test not changes exchange data');
         $connection = DriverManager::getConnection(new Configuration(Driver::AMQP, RABBIT_HOST, RABBIT_PORT, RABBIT_USERNAME, RABBIT_PASSWORD));
         $producer = new ProducerFake($connection);
         $message = $producer->prepare('test: '. rand() );


### PR DESCRIPTION
### What
Implement ACK/NACK

### Why 
On current implementation, the message receive ACK when driver fetches it. So, it is not good if some unexpected error/exception occur.

Change on AMQP Driver how to create channel, not make sense create a channel/queue name, is better create a channel/connection

fix #6 